### PR TITLE
Make Startup Zoom

### DIFF
--- a/lib/live_load/browser/connection/playwright/decompressor.ex
+++ b/lib/live_load/browser/connection/playwright/decompressor.ex
@@ -15,20 +15,28 @@ defmodule LiveLoad.Browser.Connection.Playwright.Decompressor do
   end
 
   defp do_extract(version) when is_binary(version) do
-    archive = Application.app_dir(:live_load, ["priv", "playwright", version, "playwright_bundle.tar.gz"])
+    base_path = Application.app_dir(:live_load, ["priv", "playwright", version])
 
-    if not File.exists?(archive) do
-      raise RuntimeError, """
-      The Playwright bundle does not currently exist.
+    dest = Path.join(base_path, "bin")
+    cli_path = Path.join(dest, "driver/playwright-driver")
 
-      In order to install Playwright, run `mix live_load.install` to install the default version.
-      """
+    if File.exists?(cli_path) do
+      cli_path
+    else
+      archive = Path.join(base_path, "playwright_bundle.tar.gz")
+
+      if not File.exists?(archive) do
+        raise RuntimeError, """
+        The Playwright bundle does not currently exist.
+
+        In order to install Playwright, run `mix live_load.install` to install the default version.
+        """
+      end
+
+      File.rm_rf!(dest)
+      File.mkdir_p!(dest)
+      :ok = :erl_tar.extract(String.to_charlist(archive), [:compressed, {:cwd, String.to_charlist(dest)}])
+      cli_path
     end
-
-    dest = Application.app_dir(:live_load, ["priv", "playwright", version, "bin"])
-    File.rm_rf!(dest)
-    File.mkdir_p!(dest)
-    :ok = :erl_tar.extract(String.to_charlist(archive), [:compressed, {:cwd, String.to_charlist(dest)}])
-    Path.join(dest, "driver/playwright-driver")
   end
 end

--- a/lib/live_load/topology.ex
+++ b/lib/live_load/topology.ex
@@ -84,7 +84,10 @@ defmodule LiveLoad.Topology do
           collector_pid,
           scenario_setup_timeout
         ),
-        max_concurrency: min(8, max(length(cluster.pool_node_names), 1)),
+        # Uncapped concurrency because these are each tasks that are handled on the runner nodes
+        # and there's no API or resource waits here. Capping actually slows this down a lot,
+        # because then we have to wait for slots to open up and the setup can take around 40 seconds.
+        max_concurrency: max(length(cluster.pool_node_names), 1),
         ordered: false,
         timeout: :infinity
       )

--- a/lib/live_load/topology.ex
+++ b/lib/live_load/topology.ex
@@ -74,8 +74,8 @@ defmodule LiveLoad.Topology do
     {scenario_setup_timeout, opts} = Keyword.pop(opts, :scenario_setup_timeout, to_timeout(minute: 2))
 
     :ok =
-      Enum.each(
-        cluster.pool_node_names,
+      cluster.pool_node_names
+      |> Task.async_stream(
         &Topology.Runner.setup!(
           runner_pid,
           &1,
@@ -83,8 +83,12 @@ defmodule LiveLoad.Topology do
           browser_connection_opts,
           collector_pid,
           scenario_setup_timeout
-        )
+        ),
+        max_concurrency: min(8, max(length(cluster.pool_node_names), 1)),
+        ordered: false,
+        timeout: :infinity
       )
+      |> Stream.run()
 
     try do
       with :ok <- Collector.watch_cluster(collector_pid, cluster.pool_node_names),

--- a/lib/live_load/topology/runner.ex
+++ b/lib/live_load/topology/runner.ex
@@ -4,11 +4,17 @@ defmodule LiveLoad.Topology.Runner do
   use GenServer
 
   def setup!(server, runner_node, browser_connection_adapter, browser_connection_opts, collector_pid, timeout) do
-    GenServer.call(
-      server,
-      {:setup, runner_node, browser_connection_adapter, browser_connection_opts, collector_pid},
-      timeout
-    )
+    # Assertive, but I should probably do error handling at some point...
+    {:ok, pid} =
+      :rpc.block_call(
+        runner_node,
+        LiveLoad.Scenario.Topology,
+        :setup,
+        [{browser_connection_adapter, browser_connection_opts, collector_pid}],
+        timeout
+      )
+
+    GenServer.call(server, {:link, pid}, timeout)
   end
 
   def start_link(_opts) do
@@ -21,16 +27,7 @@ defmodule LiveLoad.Topology.Runner do
   end
 
   @impl true
-  def handle_call({:setup, runner_node, browser_connection_adapter, browser_connection_opts, collector_pid}, _from, links) do
-    # Assertive, but I should probably do error handling at some point...
-    {:ok, pid} =
-      :rpc.block_call(
-        runner_node,
-        LiveLoad.Scenario.Topology,
-        :setup,
-        [{browser_connection_adapter, browser_connection_opts, collector_pid}]
-      )
-
+  def handle_call({:link, pid}, _from, links) do
     # Link the topology from the runner node to the current topology. If we go down or lose connection, everything should come down.
     Process.link(pid)
     {:reply, :ok, [pid | links]}

--- a/lib/mix/tasks/live_load/install.ex
+++ b/lib/mix/tasks/live_load/install.ex
@@ -12,11 +12,22 @@ defmodule Mix.Tasks.LiveLoad.Install do
   This must be run with the version of Playwright that is going to be used.
   The default version is #{LiveLoad.Browser.Connection.Playwright.Supervisor.playwright_version_from_env()}.
 
+  ## Options
+
+    * `--no-bundle` - does not bundle and compress the Playwright driver and browser.
+      Leaving the driver and browser compressed means that when running a load test,
+      the startup time pays a cost for unpacking the archive. Depending on the size of
+      the load test, this may take a while, as each node needs to unpack and then set up
+      the browser. Using this flag will leave the Playwright driver and browser unbundled,
+      which may result in a higher release bundle as a tradeoff.
+
 
   ## Examples
 
       $ mix live_load.install
+      $ mix live_load.install --no-bundle
       $ mix live_load.install 1.62.0
+      $ mix live_load.install 1.62.0 --no-bundle
   """
   use Mix.Task
 
@@ -28,13 +39,13 @@ defmodule Mix.Tasks.LiveLoad.Install do
   @nodejs_dist URI.new!("https://nodejs.org/dist")
   @nodejs_version "24.18.0"
 
-  @doc false
-  def run([]) do
-    default_version = LiveLoad.Browser.Connection.Playwright.Supervisor.playwright_version_from_env()
-    run([default_version])
-  end
+  @switches [no_bundle: :boolean]
 
-  def run([version]) do
+  @doc false
+  def run(args) do
+    {opts, argv} = OptionParser.parse!(args, strict: @switches)
+    version = version!(argv)
+
     Application.ensure_all_started([:inets, :ssl])
 
     priv_dir = Application.app_dir(:live_load, ["priv", "playwright"])
@@ -49,7 +60,19 @@ defmodule Mix.Tasks.LiveLoad.Install do
 
     install_driver!(driver_dir, version)
     install_browsers!(driver_dir, browsers_dir)
-    bundle!(versioned_path, driver_dir, browsers_dir)
+
+    if Keyword.get(opts, :no_bundle, false) do
+      no_bundle!(versioned_path, driver_dir, browsers_dir)
+    else
+      bundle!(versioned_path, driver_dir, browsers_dir)
+    end
+  end
+
+  defp version!([]), do: LiveLoad.Browser.Connection.Playwright.Supervisor.playwright_version_from_env()
+  defp version!([version]), do: version
+
+  defp version!(argv) do
+    Mix.raise("Expected a single Playwright version, got: #{Enum.join(argv, ", ")}")
   end
 
   defp install_driver!(driver_dir, version) do
@@ -140,9 +163,24 @@ defmodule Mix.Tasks.LiveLoad.Install do
 
     File.rm_rf!(driver_dir)
     File.rm_rf!(browsers_dir)
+    File.rm_rf!(bin_dir(versioned_path))
 
     Mix.shell().info("Compressed playwright to #{archive_path}")
   end
+
+  defp no_bundle!(versioned_path, driver_dir, browsers_dir) do
+    bin_dir = bin_dir(versioned_path)
+    File.rm_rf!(bin_dir)
+    File.mkdir_p!(bin_dir)
+
+    File.rename!(driver_dir, Path.join(bin_dir, "driver"))
+    File.rename!(browsers_dir, Path.join(bin_dir, "browsers"))
+    File.rm_rf!(Path.join(versioned_path, "playwright_bundle.tar.gz"))
+
+    Mix.shell().info("Decompressed playwright to #{bin_dir}")
+  end
+
+  defp bin_dir(versioned_path), do: Path.join(versioned_path, "bin")
 
   defp download!(url, description) do
     :ok = :public_key.cacerts_load()


### PR DESCRIPTION
This PR should take the startup time from "a lot" (over an hour on larger clusters) to minimal (from my tests, on a cluster of around 150 ish nodes it took around 5 minutes in total.

The main cause of the slowdown was the unpacking of the Playwright files, which could take around 40 seconds to a minute on Fly machines. To be honest, I'm not entirely sure why... when I checked the extraction on my local machine (a MacBook Air), it was able to extract in around 5 seconds, but whenever LiveLoad was running on Fly machines (even performance ones) the extract took almost 40 seconds. Maybe this is part of the disk that they give ephemeral compute 🤷‍♂️ 

This branch has three changes which got everything to run fast:
1. Instead of running the `Topology.Runner.setup!` call one at a time (through `Enum.each`), the setup is now run concurrently on all of the nodes (with `Task.async_stream`).
2. The concurrent `Topology.Runner.setup!` runs unbound with a `max_concurrency` value set to the number of nodes in the pool. I initially used my usual `min(8, max(length(cluster.pool_node_names), 1))` to bound it to 8 concurrent tasks, but this still ends up really slow. Not as slow... it went from around 40 minutes to around 12 minutes during my tests, but still quite slow in comparison to what it could be. These calls don't actually need to be bound, since they're not hitting APIs at all (which is why I bound the pool setup where I took this snippet from), so unbounding them took the startup time down to around 4:30.
3. Adding a `--no-bundle` option to the `mix live_load.install` task. At the end of the day, the extract part of this all takes 40 seconds per node, so if I can remove that, it drops the setup down to only the Playwright startup. This does come at a cost (the size of the release bundle), but it speeds up the startup marginally.